### PR TITLE
Updated to RFC 9457

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,7 +1,7 @@
 cff-version: 1.2.0
 message: Please use the following metadata when citing this project in your work.
 title: Petail
-abstract: A RFC 7807 Problem Details for HTTP APIs implementation.
+abstract: A RFC 9457 Problem Details for HTTP APIs implementation.
 version: 0.0.0
 license: Hippocratic-2.1
 date-released: 2025-04-05
@@ -12,7 +12,7 @@ authors:
     orcid: https://orcid.org/0000-0002-5810-6268
 keywords:
  - ruby
- - rfc7807
+ - rfc9457
  - problem_details
  - http
  - errors

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,9 +2,9 @@ cff-version: 1.2.0
 message: Please use the following metadata when citing this project in your work.
 title: Petail
 abstract: A RFC 9457 Problem Details for HTTP APIs implementation.
-version: 0.0.0
+version: 0.1.0
 license: Hippocratic-2.1
-date-released: 2025-04-05
+date-released: 2025-04-07
 authors:
   - family-names: Kuhlmann
     given-names: Brooke

--- a/README.adoc
+++ b/README.adoc
@@ -4,7 +4,7 @@
 
 = Petail
 
-Petail is a portmanteau (i.e. `[p]roblem + d[etail] = petail`) that implements link:https://datatracker.ietf.org/doc/html/rfc7807[RFC 7807: Problem Details for HTTP APIs]. This allows you to produce HTTP error responses that are structured, machine readable, and consistent.
+Petail is a portmanteau (i.e. `[p]roblem + d[etail] = petail`) that implements link:https://www.rfc-editor.org/rfc/rfc9457[RFC 9457: Problem Details for HTTP APIs]. This allows you to produce HTTP error responses that are structured, machine readable, and consistent.
 
 toc::[]
 

--- a/petail.gemspec
+++ b/petail.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name = "petail"
-  spec.version = "0.0.0"
+  spec.version = "0.1.0"
   spec.authors = ["Brooke Kuhlmann"]
   spec.email = ["brooke@alchemists.io"]
   spec.homepage = "https://alchemists.io/projects/petail"

--- a/petail.gemspec
+++ b/petail.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |spec|
   spec.authors = ["Brooke Kuhlmann"]
   spec.email = ["brooke@alchemists.io"]
   spec.homepage = "https://alchemists.io/projects/petail"
-  spec.summary = "A RFC 7807 Problem Details for HTTP APIs implementation."
+  spec.summary = "A RFC 9457 Problem Details for HTTP APIs implementation."
   spec.license = "Hippocratic-2.1"
 
   spec.metadata = {


### PR DESCRIPTION
## Overview

Necessary to refer to RFC 9457 instead of RFC 7807 since the former overrides the latter.

## Details

- Resolves Issue #1.
- See commits for details.